### PR TITLE
ServiceNow CMR Fixes - [MWPW=173724]

### DIFF
--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -83,7 +83,7 @@ jobs:
         script: |
           const notifySnowCr = require('./.github/workflows/snow-cr-notification.js');
           if (process.env.PR_STATE == 'open') {
-            await notifySnowCr({ github, context, transaction_id: process.env.TRANSACTION_ID, change_id: null, planned_start_time:  null, planned_end_time: null });
+            await notifySnowCr({ github, context, transaction_id: process.env.TRANSACTION_ID, change_id: null, planned_start_time:  process.env.PLANNED_START_TIME, planned_end_time: process.env.PLANNED_END_TIME });
           } else {
             await notifySnowCr({ github, context, transaction_id: process.env.TRANSACTION_ID, change_id: process.env.CHANGE_ID, planned_start_time: process.env.PLANNED_START_TIME, planned_end_time: process.env.PLANNED_END_TIME });
           }

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -6,6 +6,7 @@ name: Create CMR in ServiceNow
 on:
   pull_request_target:
     types:
+      - opened
       - closed
     branches:
       - servicenow-cmr-test
@@ -25,12 +26,19 @@ env:
   PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
   PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
   PR_LINK: ${{ github.event.pull_request.html_url }}
+  PR_STATE: ${{ github.event.pull_request.state }}
+  MILO_RELEASE_SLACK_WH: ${{ secrets.MILO_RELEASE_SLACK_WH }}
 
 jobs:
-  build:
-    # Only run this workflow on pull requests that have merged and not manually closed by user
-    if: github.event.pull_request.merged == true
+  create-cmr:
+    # Only run this workflow on pull requests that have been newly opened
+    if:  ${{ (github.event.pull_request.merged == true || github.event.pull_request.state == 'open') && (github.event.pull_request.base.ref == 'stage' || github.event.pull_request.base.ref == 'main') }}
     runs-on: ubuntu-latest
+    outputs:
+      TRANSACTION_ID: ${{ steps.create-cmr.outputs.transaction_id }}
+      CHANGE_ID: ${{ steps.create-cmr.outputs.change_id }}
+      PLANNED_START_TIME: ${{ steps.create-cmr.outputs.planned_start_time }}
+      PLANNED_END_TIME: ${{ steps.create-cmr.outputs.planned_end_time }}
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -41,6 +49,18 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip requests timedelta
+
     - name: Execute script for creating and closing CMR
       run: |
         python ./.github/workflows/servicenow.py
+
+    - name: Execute script for notifying of CMR state
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      with:
+        script: |
+          const notifySnowCr = require('./.github/workflows/snow-cr-notification.js');
+          if (process.env.PR_STATE == 'open') {
+            await notifySnowCr({ github, context, transaction_id: process.env.TRANSACTION_ID, change_id: null, planned_start_time:  null, planned_end_time: null });
+          } else {
+            await notifySnowCr({ github, context, transaction_id: process.env.TRANSACTION_ID, change_id: process.env.CHANGE_ID, planned_start_time: process.env.PLANNED_START_TIME, planned_end_time: process.env.PLANNED_END_TIME });
+          }

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -15,11 +15,12 @@ permissions:
   contents: read
 
 env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IMSACCESS_CLIENT_ID: ${{ secrets.IMSACCESS_CLIENT_ID }}
   IMSACCESS_CLIENT_SECRET: ${{ secrets.IMSACCESS_CLIENT_SECRET_STAGE }}
   IMSACCESS_AUTH_CODE: ${{ secrets.IMSACCESS_AUTH_CODE_STAGE }}
   IPAAS_KEY: ${{ secrets.IPAAS_KEY_STAGE }}
-  SNOW_INSTANCE_ID: ${{ secrets.SNOW_INSTANCE_ID }}
+  MILO_RELEASE_SLACK_WH: ${{ secrets.MILO_RELEASE_SLACK_WH }}
   PR_TITLE: ${{ github.event.pull_request.title }}
   PR_BODY: ${{ github.event.pull_request.body }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -27,12 +28,12 @@ env:
   PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
   PR_LINK: ${{ github.event.pull_request.html_url }}
   PR_STATE: ${{ github.event.pull_request.state }}
-  MILO_RELEASE_SLACK_WH: ${{ secrets.MILO_RELEASE_SLACK_WH }}
+  SNOW_INSTANCE_ID: ${{ secrets.SNOW_INSTANCE_ID }}
 
 jobs:
   create-cmr:
     # Only run this workflow on pull requests that have been newly opened
-    if:  ${{ (github.event.pull_request.merged == true || github.event.pull_request.state == 'open') && (github.event.pull_request.base.ref == 'stage' || github.event.pull_request.base.ref == 'main') }}
+    if:  ${{ (github.event.pull_request.merged == true || github.event.pull_request.state == 'open') }}
     runs-on: ubuntu-latest
     outputs:
       TRANSACTION_ID: ${{ steps.create-cmr.outputs.transaction_id }}
@@ -50,9 +51,31 @@ jobs:
       run: |
         python -m pip install --upgrade pip requests timedelta
 
+    - name: Retrieve transaction ID from PR Comments
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      with:
+        script: |
+          const main = require('./.github/workflows/snow-pr-comment.js')
+          if (process.env.PR_STATE == 'closed') {
+            main({ github, context })
+          } else {
+            console.log('PR is not in an closed state. Skipping...');
+          }
+
     - name: Execute script for creating and closing CMR
       run: |
         python ./.github/workflows/servicenow.py
+
+    - name: Save transaction ID in PR Comments
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      with:
+        script: |
+          const main = require('./.github/workflows/snow-pr-comment.js')
+          if (process.env.PR_STATE == 'open') {
+            main({ github, context })
+          } else {
+            console.log('PR is not in an opened state. Skipping...');
+          }
 
     - name: Execute script for notifying of CMR state
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea

--- a/.github/workflows/snow-cr-notification.js
+++ b/.github/workflows/snow-cr-notification.js
@@ -21,8 +21,8 @@ async function main({ github, context, transaction_id, change_id, planned_start_
     const { number, title, html_url } = pull_request;
     const isOpen = process.env.PR_STATE === 'open';
     const prefix = isOpen
-        ? ':exclamation: ServiceNow Change Request Created and in progress: Transaction ID: ' + transaction_id + '\n:'
-        : ':exclamation: ServiceNow Change Request Closed: Search for Change Record by Change ID: ' + change_id + '\n or Planned Start Time: ' + planned_start_time + '\n and/or Planned End Time: ' + planned_end_time + '\n:';
+        ? ':exclamation: TESTING ServiceNow Change Request Created and in progress: Transaction ID: ' + transaction_id + '\n:'
+        : ':exclamation: TESTING ServiceNow Change Request Closed: Search for Change Record by Change ID: ' + change_id + '\n or Planned Start Time: ' + planned_start_time + '\n and/or Planned End Time: ' + planned_end_time + '\n:';
 
     console.log(`Sending SNOW CR notification for PR #${number}: ${title}`);
 

--- a/.github/workflows/snow-cr-notification.js
+++ b/.github/workflows/snow-cr-notification.js
@@ -1,0 +1,40 @@
+const { slackNotification, getLocalConfigs } = require('./helpers.js');
+
+async function main({ github, context, transaction_id, change_id, planned_start_time, planned_end_time } = {}) {
+    if (!github || !context) {
+        throw new Error("GitHub context is missing. Ensure you are running in the correct environment.");
+    }
+
+    if (process.env.LOCAL_RUN) {
+        console.log("Local run detected. Loading local configurations...");
+        const localConfigs = getLocalConfigs();
+        github = localConfigs.github;
+        context = localConfigs.context;
+    }
+
+    const { pull_request } = context.payload;
+    if (!pull_request) {
+        console.log("No pull_request found in context payload. Skipping notification.");
+        return;
+    }
+
+    const { number, title, html_url } = pull_request;
+    const isOpen = process.env.PR_STATE === 'open';
+    const prefix = isOpen
+        ? ':exclamation: ServiceNow Change Request Created: Transaction ID: ' + transaction_id + '\n:'
+        : ':exclamation: ServiceNow Change Request Closed: Search for Change Record by Change ID: ' + change_id + '\n or Planned Start Time: ' + planned_start_time + '\n and/or Planned End Time: ' + planned_end_time + '\n:';
+
+    console.log(`Sending SNOW CR notification for PR #${number}: ${title}`);
+
+    await slackNotification(
+        `${prefix} <${html_url}|#${number}: ${title}>.`,
+        process.env.MILO_RELEASE_SLACK_WH
+    );
+}
+
+if (process.env.LOCAL_RUN) {
+    const { github, context } = getLocalConfigs();
+    main({ github, context });
+}
+
+module.exports = main;

--- a/.github/workflows/snow-cr-notification.js
+++ b/.github/workflows/snow-cr-notification.js
@@ -21,7 +21,7 @@ async function main({ github, context, transaction_id, change_id, planned_start_
     const { number, title, html_url } = pull_request;
     const isOpen = process.env.PR_STATE === 'open';
     const prefix = isOpen
-        ? ':exclamation: ServiceNow Change Request Created: Transaction ID: ' + transaction_id + '\n:'
+        ? ':exclamation: ServiceNow Change Request Created and in progress: Transaction ID: ' + transaction_id + '\n:'
         : ':exclamation: ServiceNow Change Request Closed: Search for Change Record by Change ID: ' + change_id + '\n or Planned Start Time: ' + planned_start_time + '\n and/or Planned End Time: ' + planned_end_time + '\n:';
 
     console.log(`Sending SNOW CR notification for PR #${number}: ${title}`);

--- a/.github/workflows/snow-pr-comment.js
+++ b/.github/workflows/snow-pr-comment.js
@@ -1,0 +1,77 @@
+// Run from the root of the project for local testing: node --env-file=.env .github/workflows/pr-reminders.js
+const { getLocalConfigs } = require('./helpers.js');
+const { fs } = require('fs');
+
+const main = async ({ github, context }) => {
+  const comment = async ({ pr_number, message, comments, transaction_id }) => {
+    if (comments.some((c) => c.body.includes(message))) {
+      console.log(
+        `SNOW Transaction Comment exists. Commenting skipped... ${message}`
+      );
+      return;
+    }
+    process.env.LOCAL_RUN
+      ? console.log(
+          `PR #${pr_number} Local execution commenting SKIPPED message for SNOW Transaction ID ${transaction_id}: ${message}`
+        )
+      : await github.rest.issues
+          .createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr_number,
+            body: message,
+          })
+          .then(() => console.log(`PR #${pr_number} Commented for SNOW Transaction ID ${transaction_id}: ${message}`))
+          .catch(console.error);
+  };
+
+  try {
+    const { data: comments } = await github.rest.issues.listComments({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: process.env.PR_NUMBER,
+    });
+
+    if (process.env.PR_STATE !== 'open') {
+      let foundTransactionId = false;
+      for await (const singleComment of comments) {
+        if (singleComment.body.includes("SNOW Change Request Transaction ID: ")) {
+          console.log(`Found SNOW Transaction ID Comment. Assigning transaction ID for closing SNOW Change Request...`);
+          foundTransactionId = true;
+          const transaction_id = singleComment.body.split("SNOW Change Request Transaction ID: ")[1].trim();
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `TRANSACTION_ID=${transaction_id}\n`);
+          break;
+        }
+      }
+      if (!foundTransactionId) {
+        console.log(`No SNOW Transaction ID Comment found. Skipping...`);
+        return;
+      }
+    }
+    else if (process.env.TRANSACTION_ID) {
+      comment({
+        pr_number: process.env.PR_NUMBER,
+        comments,
+        transaction_id: process.env.TRANSACTION_ID,
+        message:
+          'SNOW Change Request Transaction ID: ' + process.env.TRANSACTION_ID,
+      });
+    }
+    else {
+      console.log(`No SNOW Transaction ID found. Can't make PR comment. Skipping...`);
+      return;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+if (process.env.LOCAL_RUN) {
+  const { github, context } = getLocalConfigs();
+  main({
+    github,
+    context,
+  });
+}
+
+module.exports = main;


### PR DESCRIPTION
Fixes these issues:

- ServiceNow Registry InstanceID that was retired has now been changed to correct ID
- GitHub action only runs when merges are closed or open against the production branch. This now includes branches from forks being directly merged into the production branch for hot-fixes
- Fixed SNOW API payload values for planned start and end time to be whole integers rather than timestamp floats

Enhancements:

- Leveraging Python F-strings where needed
- Cleaned up functions to follow linting rules
- Updated release summary information for Change Requests to include PR URLs.
- Updated print statements to provide clarity for instructions for finding Change Requests (CRs) and/or debugging when a CR isn't found
- Slack notification with CR information
- Persisting of SNOW Change Request Transaction ID in PR Comments to aide in CMR process from PR open to close state

Resolves: MWPW-173724

Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://servicenow-cmr-MWPW-173724--milo--adobecom.aem.page/?martech=off

