### PR TITLE
ServiceNow CMR Fixes - [MWPW=173724]

### DIFF
--- a/.github/workflows/servicenow.py
+++ b/.github/workflows/servicenow.py
@@ -6,8 +6,6 @@ import sys
 import time
 import requests
 
-# Global Variables
-
 APPLICATION_JSON = "application/json"
 CMR_RETRIEVAL_ERROR = "CMR ID Retrieval Operation failed..."
 POST_FAILURE_MESSAGE = "POST failed with response code: "

--- a/.github/workflows/servicenow.py
+++ b/.github/workflows/servicenow.py
@@ -225,7 +225,7 @@ if __name__ == "__main__":
       print(f"IMS token request was successful: {response.status_code}")
       token = json_parse["access_token"]
 
-    servicenow_get_cmr_url = f'{SERVICENOW_GET_CMR_URL}{os.environ["TRANSACTION_ID"]}'
+    servicenow_get_cmr_url = f'{SERVICENOW_GET_CMR_URL}{os.environ["RETRIEVED_TRANSACTION_ID"]}'
     headers = {
       "Accept": APPLICATION_JSON,
       "Authorization":token,
@@ -259,7 +259,7 @@ if __name__ == "__main__":
       "api_key":os.environ['IPAAS_KEY']
     }
     data = {
-      "id": os.environ['TRANSACTION_ID'],
+      "id": os.environ['RETRIEVED_TRANSACTION_ID'],
       "actualStartDate": actual_start_time,
       "actualEndDate": actual_end_time,
       "state": "Closed",
@@ -286,4 +286,4 @@ if __name__ == "__main__":
     print("")
     print(f"If the CMR ID is not found, search for the change record in ServiceNow by the planned start time {os.environ['PLANNED_START_TIME']} and/or planned end time {os.environ['PLANNED_END_TIME']}.")
     print("")
-    print(f"If all else fails, please check the ServiceNow queue for transaction ID '{os.environ['TRANSACTION_ID']}' and validate that the CMR was created successfully by reaching out to the Change Management team in the #unified-change-management-support slack channel.")
+    print(f"If all else fails, please check the ServiceNow queue for transaction ID '{os.environ['RETRIEVED_TRANSACTION_ID']}' and validate that the CMR was created successfully by reaching out to the Change Management team in the #unified-change-management-support slack channel.")

--- a/.github/workflows/servicenow.py
+++ b/.github/workflows/servicenow.py
@@ -6,6 +6,8 @@ import sys
 import time
 import requests
 
+# Global Variables
+
 APPLICATION_JSON = "application/json"
 CMR_RETRIEVAL_ERROR = "CMR ID Retrieval Operation failed..."
 POST_FAILURE_MESSAGE = "POST failed with response code: "

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -36,10 +36,11 @@ jobs:
     if:  ${{ (github.event.pull_request.merged == true || github.event.pull_request.state == 'open') }}
     runs-on: ubuntu-latest
     outputs:
-      TRANSACTION_ID: ${{ steps.create-cmr.outputs.transaction_id }}
-      CHANGE_ID: ${{ steps.create-cmr.outputs.change_id }}
-      PLANNED_START_TIME: ${{ steps.create-cmr.outputs.planned_start_time }}
-      PLANNED_END_TIME: ${{ steps.create-cmr.outputs.planned_end_time }}
+      RETRIEVED_TRANSACTION_ID: ${{ steps.retrieve-transactionId-step.outputs.transaction_id }}
+      TRANSACTION_ID: ${{ steps.create-close-cmr-step.outputs.transaction_id }}
+      CHANGE_ID: ${{ steps.create-close-cmr-step.outputs.change_id }}
+      PLANNED_START_TIME: ${{ steps.create-close-cmr-step.outputs.planned_start_time }}
+      PLANNED_END_TIME: ${{ steps.create-close-cmr-step.outputs.planned_end_time }}
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -52,33 +53,46 @@ jobs:
         python -m pip install --upgrade pip requests timedelta
 
     - name: Retrieve transaction ID from PR Comments
+      id: retrieve-transactionId-step
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       with:
         script: |
           const main = require('./.github/workflows/snow-pr-comment.js')
           if (process.env.PR_STATE == 'closed') {
-            main({ github, context })
+            main({ github, context, transaction_id: null })
           } else {
             console.log('PR is not in an closed state. Skipping...');
           }
 
     - name: Execute script for creating and closing CMR
+      id: create-close-cmr-step
+      env:
+        RETRIEVED_TRANSACTION_ID: ${{ steps.retrieve-transactionId-step.outputs.transaction_id }}
       run: |
         python ./.github/workflows/servicenow.py
 
     - name: Save transaction ID in PR Comments
+      id: pr-comment-snow-cr-step
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      env:                                         
+        TRANSACTION_ID: ${{ steps.create-close-cmr-step.outputs.transaction_id }}
       with:
         script: |
           const main = require('./.github/workflows/snow-pr-comment.js')
           if (process.env.PR_STATE == 'open') {
-            main({ github, context })
+            main({ github, context, transaction_id: process.env.TRANSACTION_ID })
           } else {
             console.log('PR is not in an opened state. Skipping...');
           }
 
     - name: Execute script for notifying of CMR state
+      id: slack-snow-cr-step
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      env:
+        TRANSACTION_ID: ${{ steps.create-close-cmr-step.outputs.transaction_id }}
+        CHANGE_ID: ${{ steps.create-close-cmr-step.outputs.change_id }}
+        PLANNED_START_TIME: ${{ steps.create-close-cmr-step.outputs.planned_start_time }}
+        PLANNED_END_TIME: ${{ steps.create-close-cmr-step.outputs.planned_end_time }}
       with:
         script: |
           const notifySnowCr = require('./.github/workflows/snow-cr-notification.js');


### PR DESCRIPTION
Fixes these issues:

- ServiceNow Registry InstanceID that was retired has now been changed to correct ID
- Back-off timer has been updated to have an hour timeout since in high peak times the Kafka queue for the SNOW Change Request API may take a long time to complete requests.
- GitHub action only runs when merges are closed against the production branch. This now includes branches from forks being directly merged into the production branch for hot-fixes.
- Fixed API payload values for planned start and end time to be whole integers rather than timestamp floats.

Enhancements:

- Leveraging Python F-strings where needed
- Cleaned up functions to follow linting rules
- Updated release summary information for Change Requests to include PR URLs.
- Updated print statements to provide clarity for instructions for finding Change Requests (CRs) and/or debugging when a CR isn't found.
- Slack notification with CR information

Resolves: MWPW-173724

Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://servicenow-cmr-MWPW-173724--milo--adobecom.aem.page/?martech=off




