### PR TITLE
ServiceNow CMR Fixes - [MWPW=173724]

### DIFF
--- a/.github/workflows/servicenow.py
+++ b/.github/workflows/servicenow.py
@@ -6,6 +6,8 @@ import sys
 import time
 import requests
 
+# Global Variables
+
 APPLICATION_JSON = "application/json"
 CMR_RETRIEVAL_ERROR = "CMR ID Retrieval Operation failed..."
 POST_FAILURE_MESSAGE = "POST failed with response code: "

--- a/.github/workflows/snow-pr-comment.js
+++ b/.github/workflows/snow-pr-comment.js
@@ -20,6 +20,7 @@ const main = async ({ github, context, transaction_id }) => {
             repo: context.repo.repo,
             issue_number: pr_number,
             body: message,
+            token: process.env.GITHUB_TOKEN,
           })
           .then(() => console.log(`PR #${pr_number} Commented for SNOW Transaction ID ${_transaction_id}: ${message}`))
           .catch(console.error);
@@ -39,7 +40,7 @@ const main = async ({ github, context, transaction_id }) => {
           console.log(`Found SNOW Transaction ID Comment. Assigning transaction ID for closing SNOW Change Request...`);
           foundTransactionId = true;
           const transactionId = singleComment.body.split("SNOW Change Request Transaction ID: ")[1].trim();
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, `TRANSACTION_ID=${transactionId}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `RETRIEVED_TRANSACTION_ID=${transactionId}\n`);
           break;
         }
       }


### PR DESCRIPTION
Fixes these issues:

- ServiceNow Registry InstanceID that was retired has now been changed to correct ID
- Back-off timer has been updated to have an hour timeout since in high peak times the Kafka queue for the SNOW Change Request API may take a long time to complete requests.
- GitHub action only runs when merges are closed against the production branch. This now includes branches from forks being directly merged into the production branch for hot-fixes.
- Fixed API payload values for planned start and end time to be whole integers rather than timestamp floats.

Enhancements:

- Leveraging Python F-strings where needed
- Cleaned up functions to follow linting rules
- Updated release summary information for Change Requests to include PR URLs.
- Updated print statements to provide clarity for instructions for finding Change Requests (CRs) and/or debugging when a CR isn't found.
- Slack notification with CR information

Resolves: MWPW-173724

**Test URLs:**

- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://servicenow-cmr-MWPW-173724--milo--adobecom.aem.page/?martech=off

