### PR TITLE
ServiceNow CMR Fixes - [MWPW=173724]

### DIFF
--- a/.github/workflows/servicenow.py
+++ b/.github/workflows/servicenow.py
@@ -6,7 +6,6 @@ import sys
 import time
 import requests
 
-# Global Variables
 
 APPLICATION_JSON = "application/json"
 CMR_RETRIEVAL_ERROR = "CMR ID Retrieval Operation failed..."

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -12,6 +12,7 @@ on:
       - servicenow-cmr-test-2
 
 permissions:
+  pull-requests: write
   contents: read
 
 env:


### PR DESCRIPTION
Fixes these issues:

- ServiceNow Registry InstanceID that was retired has now been changed to correct ID
- Back-off timer has been updated to have an hour timeout since in high peak times the Kafka queue for the SNOW Change Request API may take a long time to complete requests.
- GitHub action only runs when merges are closed against the production branch. This now includes branches from forks being directly merged into the production branch for hot-fixes.
- Fixed API payload values for planned start and end time to be whole integers rather than timestamp floats.

Enhancements:

- Leveraging Python F-strings where needed
- Cleaned up functions to follow linting rules
- Updated release summary information for Change Requests to include PR URLs.
- Updated print statements to provide clarity for instructions for finding Change Requests (CRs) and/or debugging when a CR isn't found.
- Slack notification with CR information

Resolves: MWPW-173724

**Test URLs:**

- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://servicenow-cmr-MWPW-173724--milo--adobecom.aem.page/?martech=off




